### PR TITLE
Update definition_parsing_methods.py

### DIFF
--- a/lexnlp/extract/en/definition_parsing_methods.py
+++ b/lexnlp/extract/en/definition_parsing_methods.py
@@ -131,8 +131,7 @@ PAREN_PTN = r"""\((?:E|each(?:,)?\s+)?(?:(?:{articles})\s+)?([A-Z][^\)]{{1,{max_
     .format(articles=join_collection(ARTICLES), max_term_chars=MAX_TERM_CHARS)
 PAREN_PTN_RE_OPTIONS = re.UNICODE | re.DOTALL | re.MULTILINE | re.VERBOSE
 
-# Case 3. Term is without quotes, is preceded by word|term|phrase or :,.^
-# and has TRIGGER_LIST item after itself.
+# Case 3. Term is without quotes, and has TRIGGER_LIST item after itself.
 # e.g.: "Revolving Loan Commitment means…"; "LIBOR Rate shall mean…"
 # false positive: "This Borrower Joiner Agreement to the extent signed signed and delivered by means of a facsimile..."
 NOUN_PTN_BASE = r"""


### PR DESCRIPTION
The documentation for case 3. is confusing, it is the same as that for case 1. However the difference is that case 3 does not actually look for Term being preceded by "word(s)|phrase(s)|term(s)".